### PR TITLE
feat(multi-session): Allow switching multi-sessions in different child processes

### DIFF
--- a/cast/app.py
+++ b/cast/app.py
@@ -26,19 +26,21 @@ def setup_default_session(session_id):
 
     return app.config["sessions"][session_id]
 
-def read_and_forward_pty_output():
+def read_and_forward_pty_output(session_id):
     max_read_bytes = 1024 * 20
+    app.config["current_session"] = session_id
     while True:
 
-        file_desc = app.config["sessions"][app.config["current_session"]]["fd"]
+        if session_id in app.config["sessions"]:
+            file_desc = app.config["sessions"][app.config["current_session"]]["fd"]
 
-        socketio.sleep(0.01)
-        if file_desc:
-            timeout_sec = 0
-            (data_ready, _, _) = select.select([file_desc], [], [], timeout_sec)
-            if data_ready:
-                output = os.read(file_desc, max_read_bytes).decode()
-                socketio.emit("client-output", {"output": output, "ssid": app.config["current_session"] }, namespace="/cast")
+            socketio.sleep(0.01)
+            if file_desc:
+                timeout_sec = 0
+                (data_ready, _, _) = select.select([file_desc], [], [], timeout_sec)
+                if data_ready:
+                    output = os.read(file_desc, max_read_bytes).decode()
+                    socketio.emit("client-output", {"output": output, "ssid": app.config["current_session"] }, namespace="/cast")
 
 
 @app.route("/")
@@ -49,27 +51,78 @@ def index():
 @socketio.on("client-input", namespace="/cast")
 def client_input(data):
 
-    # Update current session    
+    # Update current session
     app.config["current_session"] = data["session_id"]
+    print("input: {}".format(app.config["sessions"]))
 
-    file_desc = app.config["sessions"][data["session_id"]]["fd"]
-    
-    if file_desc: os.write(file_desc, data["input"].encode())
+    if data["session_id"] in app.config["sessions"]:
+        file_desc = app.config["sessions"][data["session_id"]]["fd"]
 
-@socketio.on("connect", namespace="/cast")
-def connect():
+        if file_desc:
+            if data["input"] == '':
+                # When switching session, send a key to update terminal content
+                os.write(file_desc, b'\x00')
+            else:
+                os.write(file_desc, data["input"].encode())
 
-    session = setup_default_session(request.args.get('session_id'))
 
-    if (session["child_pid"]): return
+@socketio.on("new-session", namespace="/cast")
+def new_session(data=None):
+    """To register session on WebSocket server
+    Similar to 'connect()'
+    """
+    session_id = ''
+    if data is not None:
+        session_id = data["session_id"]
+    print("new-session: {}\n\n".format(session_id))
+
+    if session_id in app.config["sessions"].keys():
+        return
+
 
     (child_pid, fd) = pty.fork()
 
     if child_pid == 0:
         subprocess.run(app.config["cmd"])
     else:
-        session["fd"] = fd
-        session["child_pid"] = child_pid
+        app.config["sessions"][session_id] = {}
+        app.config["sessions"][session_id]["fd"] = fd
+        app.config["sessions"][session_id]["child_pid"] = child_pid
+
+        cmd = " ".join(shlex.quote(c) for c in app.config["cmd"])
+
+        print("child pid is", child_pid)
+        print(
+            "starting background task with command `{cmd}` to continously read "
+            "and forward pty output to client"
+        )
+
+        socketio.start_background_task(target=read_and_forward_pty_output, session_id=session_id)
+
+        print("task started")
+
+
+@socketio.on("connect", namespace="/cast")
+def connect():
+    session_id = request.values.get('session_id') if not request.values.get('session_id') == None else ''
+    if session_id == '' and data is not None:
+        session_id = data["session_id"]
+        print("new-session: {}\n\n".format(session_id))
+
+    # Create new session only when ssid does not in records
+    if session_id in app.config["sessions"].keys():
+        return
+
+
+    (child_pid, fd) = pty.fork()
+
+    if child_pid == 0:
+        subprocess.run(app.config["cmd"])
+    else:
+        # Store sessions by ssid
+        app.config["sessions"][session_id] = {}
+        app.config["sessions"][session_id]["fd"] = fd
+        app.config["sessions"][session_id]["child_pid"] = child_pid
        
         cmd = " ".join(shlex.quote(c) for c in app.config["cmd"])
        
@@ -79,7 +132,8 @@ def connect():
             "and forward pty output to client"
         )
        
-        socketio.start_background_task(target=read_and_forward_pty_output)
+        # Output terminal message corresponding to ssid
+        socketio.start_background_task(target=read_and_forward_pty_output, session_id=session_id)
        
         print("task started")
 


### PR DESCRIPTION
for #5 
Known limitation: for continuing processes, like `top`, there could be showing messages to another terminal when switching the tab. It is due to delay of WebSocket server receiving the switching current session. User need to press Enter to get the control of the tab.