### PR TITLE
fix busy wait starving the CPU; minor tweaks

### DIFF
--- a/cast/app.py
+++ b/cast/app.py
@@ -29,12 +29,14 @@ def setup_default_session(session_id):
 def read_and_forward_pty_output(session_id):
     max_read_bytes = 1024 * 20
     app.config["current_session"] = session_id
+
     while True:
+
+        socketio.sleep(0.01)
 
         if session_id in app.config["sessions"]:
             file_desc = app.config["sessions"][app.config["current_session"]]["fd"]
 
-            socketio.sleep(0.01)
             if file_desc:
                 timeout_sec = 0
                 (data_ready, _, _) = select.select([file_desc], [], [], timeout_sec)
@@ -60,7 +62,7 @@ def client_input(data):
 
         if file_desc:
             if data["input"] == '':
-                # When switching session, send a key to update terminal content
+                # When switching sessions, send a key to update terminal content
                 os.write(file_desc, b'\x00')
             else:
                 os.write(file_desc, data["input"].encode())
@@ -76,30 +78,31 @@ def new_session(data=None):
         session_id = data["session_id"]
     print("new-session: {}\n\n".format(session_id))
 
-    if session_id in app.config["sessions"].keys():
+    if session_id in app.config["sessions"]:
         return
-
 
     (child_pid, fd) = pty.fork()
 
     if child_pid == 0:
+        # child: run system command
         subprocess.run(app.config["cmd"])
     else:
+        # parent: stream input/output from child to Socketio web channel
         app.config["sessions"][session_id] = {}
         app.config["sessions"][session_id]["fd"] = fd
         app.config["sessions"][session_id]["child_pid"] = child_pid
 
         cmd = " ".join(shlex.quote(c) for c in app.config["cmd"])
 
-        print("child pid is", child_pid)
+        print("new-session: child pid is", child_pid)
         print(
-            "starting background task with command `{cmd}` to continously read "
+            f"new-session: starting background task with command `{cmd}` to continously read "
             "and forward pty output to client"
         )
 
         socketio.start_background_task(target=read_and_forward_pty_output, session_id=session_id)
 
-        print("task started")
+        print("new-session: task started")
 
 
 @socketio.on("connect", namespace="/cast")
@@ -107,18 +110,19 @@ def connect(data=None):
     session_id = request.values.get('session_id') if not request.values.get('session_id') == None else ''
     if session_id == '' and data is not None:
         session_id = data["session_id"]
-        print("new-session: {}\n\n".format(session_id))
+        print("connect: {}\n\n".format(session_id))
 
-    # Create new session only when ssid does not in records
-    if session_id in app.config["sessions"].keys():
+    # Create new session only when id not in records
+    if session_id in app.config["sessions"]:
         return
-
 
     (child_pid, fd) = pty.fork()
 
     if child_pid == 0:
+        # child: start system command
         subprocess.run(app.config["cmd"])
     else:
+        # parent: print info, stream child input/output to socketio
         # Store sessions by ssid
         app.config["sessions"][session_id] = {}
         app.config["sessions"][session_id]["fd"] = fd
@@ -126,16 +130,16 @@ def connect(data=None):
        
         cmd = " ".join(shlex.quote(c) for c in app.config["cmd"])
        
-        print("child pid is", child_pid)
+        print("connect: child pid is", child_pid)
         print(
-            "starting background task with command `{cmd}` to continously read "
+            f"connect: starting background task with command `{cmd}` to continously read "
             "and forward pty output to client"
         )
        
         # Output terminal message corresponding to ssid
         socketio.start_background_task(target=read_and_forward_pty_output, session_id=session_id)
        
-        print("task started")
+        print("connect: task started")
 
 
 def main():
@@ -161,7 +165,7 @@ def main():
     if args.version:
         print(__version__)
         exit(0)
-    print("serving on http://0.0.0.0:{args.port}")
+    print(f"serving on http://0.0.0.0:{args.port}")
     app.config["cmd"] = [args.command] + shlex.split(args.cmd_args)
     socketio.run(app, host="0.0.0.0", debug=args.debug, port=args.port)
 


### PR DESCRIPTION

## Description

Hi! This patch fixes a bug, and makes a number of minor tweaks to the Cast project:

- there was a busy-wait in the code, consuming CPU. This was fixed by moving `socketio.sleep` to the body of the loop.

- some print strings didn't output their values, e.g. the port number; fixed

- messages printed from the new-session and connect functions are now clearer; each message is prefixed with the parent function call name

- a few typos were neatened up

## Type of change

- New feature (non-breaking change which adds functionality)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
