### PR TITLE
clear session during refresh

### DIFF
--- a/cast/app.js
+++ b/cast/app.js
@@ -95,7 +95,7 @@ const openSession = (tid) => {
 const newTab = (ssid) => {
   let tab = document.createElement("div");
   tab.className = "tab";
-  tab.innerText = ssid;
+  tab.innerText = "tab";
   tab.id = TID;
 
   tabs.push({ tid: TID, ssid: ssid, session: null });

--- a/cast/app.js
+++ b/cast/app.js
@@ -95,7 +95,7 @@ const openSession = (tid) => {
 const newTab = (ssid) => {
   let tab = document.createElement("div");
   tab.className = "tab";
-  tab.innerText = "tab";
+  tab.innerText = "tab " + (sessions.length+1);
   tab.id = TID;
 
   tabs.push({ tid: TID, ssid: ssid, session: null });

--- a/cast/app.py
+++ b/cast/app.py
@@ -128,6 +128,8 @@ def connect(data=None):
     else:
         # parent: print info, stream child input/output to socketio
         # Store sessions by ssid
+        print("opening a new session")
+        app.config["sessions"] = {}
         app.config["sessions"][session_id] = {}
         app.config["sessions"][session_id]["fd"] = fd
         app.config["sessions"][session_id]["child_pid"] = child_pid


### PR DESCRIPTION
- Clear session whenever user refreshes the page
- backend logs and UI will be consistent (showing only active sessions)

#18 