### PR TITLE
Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 
 python:
+  - 3.5
   - 3.6
   - 3.7
 

--- a/cast/app.py
+++ b/cast/app.py
@@ -98,8 +98,8 @@ def new_session(data=None):
 
         print("new-session: child pid is", child_pid)
         print(
-            f"new-session: starting background task with command `{cmd}` to continously read "
-            "and forward pty output to client"
+            "new-session: starting background task with command `{}` to continously read "
+            "and forward pty output to client".format(cmd)
         )
 
         socketio.start_background_task(
@@ -138,8 +138,8 @@ def connect(data=None):
 
         print("connect: child pid is", child_pid)
         print(
-            f"connect: starting background task with command `{cmd}` to continously read "
-            "and forward pty output to client"
+            "connect: starting background task with command `{}` to continously read "
+            "and forward pty output to client".format(cmd)
         )
 
         # Output terminal message corresponding to ssid
@@ -175,7 +175,7 @@ def main():
     if args.version:
         print(__version__)
         exit(0)
-    print(f"serving on http://0.0.0.0:{args.port}")
+    print("serving on http://0.0.0.0:{}".format(args.port))
     app.config["cmd"] = [args.command] + shlex.split(args.cmd_args)
     socketio.run(app, host="0.0.0.0", debug=args.debug, port=args.port)
 


### PR DESCRIPTION
## Description

Removed f-strings and moved to str.format() to support py3.5.
Added 3.5 version to CI build

Added Python support to allow more people to utilize package.  Opens usage to more people. 
Referencing #27

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran program locally and checked it worked with 3.5 on Arch Linux.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
