### PR TITLE
Double Click event for editing the tab names

### DIFF
--- a/cast/app.css
+++ b/cast/app.css
@@ -92,6 +92,7 @@ a {
   height: inherit;
   background-color: #1f1f1f;
   color: white;
+  cursor: pointer;
 }
 
 #create-tab, .tab {
@@ -115,13 +116,17 @@ a {
   margin: 0 1px;
 }
 
+.tab:hover {
+  cursor: pointer;
+}
 
 .tab.active {
   background: greenyellow;
   color:black;
 }
 
-.tab:focus {
+.tab.active:focus {
   background:goldenrod;
   outline: greenyellow;
+  cursor: text;
 }

--- a/cast/app.js
+++ b/cast/app.js
@@ -4,6 +4,7 @@ var tabs = []
 var close = []
 var closedTabs = []
 var sessions = [];
+var clickCount = 0;
 var TID = 0;
 const MAX_LINES = 9999999;
 let socket;
@@ -124,10 +125,17 @@ const closeSession = (tid) => {
 const newTab = (ssid) => {
   let tab = document.createElement("div");
   tab.className = "tab";
-  tab.contentEditable = true;
   tab.innerText = "tab " + (sessions.length + 1);
   tab.id = TID;
-  tab.onkeydown = function(e) {
+  tabs.push({ tid: TID, ssid: ssid, session: null });
+  return tab;
+}
+
+const editTab = (tid) => {
+  let tablink = document.getElementById(tid);
+  tablink.contentEditable = true;
+  tablink.focus();
+  tablink.onkeydown = function(e) {
     console.log('keydown');
     if (!e) {
       e = window.event;
@@ -143,12 +151,9 @@ const newTab = (ssid) => {
         e.returnValue = false;
       }
       target.blur();
+      tablink.contentEditable = false;
     }
   }
-
-
-  tabs.push({ tid: TID, ssid: ssid, session: null });
-  return tab;
 }
 
 const closeButton = (ssid) => {
@@ -167,11 +172,27 @@ const appendTab = (ssid) => {
 
   let tab = newTab(ssid);
   let close = closeButton(ssid);
+
   tab.addEventListener('click', (e) => {
-    console.log(e.target.id);
-    openSession(e.target.id);
+    clickCount++;
     currentSsid = ssid;
-  })
+    if (clickCount === 1) {
+        singleClickTimer = setTimeout(function() {
+            clickCount = 0;
+            openSession(e.target.id);
+        }, 150);
+    } else if (clickCount === 2) {
+        clearTimeout(singleClickTimer);
+        clickCount = 0;
+        if(closedTabs.includes(e.target.id)){
+          //pass
+        } else {
+          focusStyle(e.target.id);
+          editTab(e.target.id);
+        }
+    }
+}, false)
+  
 
   close.addEventListener('click', (e) => {
     console.log(e.target.id);


### PR DESCRIPTION
# Tab Name Editing

## Description
The doubleclick of the tab will now allow the user to edit the tab name. This will set the content when `enter` is pressed.

Fixes Issue  #44 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
